### PR TITLE
Devpl 2719 hmac verification

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,3 +4,4 @@ README.md
 assets/
 
 src/webflow/oauth.py
+src/webflow/signature.py

--- a/src/webflow/signature.py
+++ b/src/webflow/signature.py
@@ -1,0 +1,21 @@
+# If we can I'd like to move this to the webhooks client wrapper, 
+# but I can't find the Fern generation.yml to extend the client 
+# according to documentation included here:
+# https://buildwithfern.com/learn/sdks/capabilities/custom-code
+import hmac
+import hashlib
+from collections.abc import Mapping
+
+def verify(headers: Mapping, body:str , secret: str):
+    # Normalize header format to account for different server implementations
+    normalized_headers = {k.lower(): v for k, v in headers.items()}
+
+    message = f"{normalized_headers.get('x-webflow-timestamp', '')}:{body}".encode('utf-8')
+
+    generated_signature = hmac.new(
+        key=secret.encode('utf-8'),
+        msg=message,
+        digestmod=hashlib.sha256
+    ).hexdigest()
+
+    return normalized_headers.get("x-webflow-signature", "") == generated_signature

--- a/src/webflow/signature.py
+++ b/src/webflow/signature.py
@@ -7,7 +7,8 @@ import hashlib
 from collections.abc import Mapping
 
 def verify(headers: Mapping, body:str , secret: str):
-    # Normalize header format to account for different server implementations
+    # Normalize header format to account for different python server implementations 
+    # that may or may not normalize headers already
     normalized_headers = {k.lower(): v for k, v in headers.items()}
 
     message = f"{normalized_headers.get('x-webflow-timestamp', '')}:{body}".encode('utf-8')

--- a/src/webflow/signature.py
+++ b/src/webflow/signature.py
@@ -7,6 +7,47 @@ import hashlib
 from collections.abc import Mapping
 
 def verify(headers: Mapping, body:str , secret: str):
+    """
+    Verify that the signature on the webhook message is from Webflow
+
+    Documentation:
+    https://developers.webflow.com/data/docs/working-with-webhooks#validating-request-signatures
+
+    Parameters:
+        - headers : Mapping. The request headers in a Mapping-like object
+
+        - body : str. The request body as a UTF-8 encoded string
+
+        - secret : str. The secret key generated when creating the webhook or the OAuth client secret
+    ---
+    ```
+    from fastapi import FastAPI, Request
+    # ...
+
+    @app.post('/webhookEndpoint')
+    async def webhook_endpoint_handler(
+        request: Request,
+    ):
+        # Read the request body as a utf-8 encoded string
+        body = (await request.body()).decode("utf-8")  
+    
+        # Extract the headers as Mapping-like object
+        headers = request.headers
+
+        secret = get_secret()
+        
+        verified = verify(
+            headers=request.headers, 
+            body=(await request.body()).decode("utf-8"), 
+            secret=new_webhook.secretKey)
+
+        if verified:
+            # ...process the request normally
+        else:
+            # ...handle unathenticated request
+    ```
+    """
+    
     # Normalize header format to account for different python server implementations 
     # that may or may not normalize headers already
     normalized_headers = {k.lower(): v for k, v in headers.items()}


### PR DESCRIPTION
JS SDK changes: https://github.com/webflow/js-webflow-api/pull/214

## Description
Developer documentation will be updated to push users to use the SDK rather than build their own solution to verify signatures. The reason is because we may change signature generation in the future, and using the SDK will allow users to simply update the WebflowAPI package. This means that the function signature should remain the same between versions. However, because Request objects vary between server implementations, I don't think it's feasible to allow users to pass in the request-like object to the function and expect things to work. Since HMAC generation will always include a secret key, header information, and the request body– I think we can safely require users to pass in these parameters in the expected format without breaking them in the future. 

1. If we need access to the request body fields, we can always transform it into a JSON object. 
2. While headers may be subject to change, passing in the whole headers collection as a record allows us the flexibility to access whatever we need.

Here's a link to the related PR for updating the docs:
https://github.com/webflow/openapi-internal/pull/342

## Usage 
To use the new function, users will break the http request down into its relevant parts and pass them into the function, which will return a promise that resolves to a Boolean representing whether the signature is valid.

### Example
```typescript
    @app.post('/webhookEndpoint')
    async def webhook_endpoint_handler(
        request: Request,
    ):
        # Read the request body as a utf-8 encoded string
        body = (await request.body()).decode("utf-8")  
    
        # Extract the headers as Mapping-like object
        headers = request.headers

        secret = get_secret()
        
        verified = verify(
            headers=request.headers, 
            body=(await request.body()).decode("utf-8"), 
            secret=new_webhook.secretKey)

        if verified:
            # ...process the request normally
        else:
            # ...handle unathenticated request
     
```

## Test Plan
### OAuth App generated webhooks
OAuth App generated webhooks will not have a secret key and will continue to use the associated Client Secret to verify HMAC signatures as detailed in the [Working with Webhooks documentation](https://developers.webflow.com/data/docs/working-with-webhooks#validating-request-signatures)
To test:
1. Generate a webhook through the Auth'd application
2. Trigger the webhook, setup your handler to pass in the Client Secret Key into the `secret` field of the of the `#verify` function

### New client only Secret Key
1. In the Webflow dashboard, navigate to a site's Apps & Integrations tab and add a new webhook
4. Add the generated Secret Key to your local application and setup your handler to pass it into the `secret` field of the of the `#verify` function
5. Trigger the webhook